### PR TITLE
Tightened code styling rules in Checkstyle config

### DIFF
--- a/src/main/resources/fcrepo-checkstyle/checkstyle-suppressions.xml
+++ b/src/main/resources/fcrepo-checkstyle/checkstyle-suppressions.xml
@@ -3,4 +3,10 @@
      "-//Puppy Crawl//DTD Suppressions 1.1//EN"
      "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
+  <suppress checks="JavadocMethod" files="src[/\\]test[/\\]java"/>
+  <suppress checks="JavadocPackage" files="src[/\\]test[/\\]java"/>
+  <suppress checks="JavadocVariable" files="src[/\\]test[/\\]java"/>
+  <suppress checks="JavadocType" files="src[/\\]test[/\\]java"/>
+  <suppress checks="JavadocStyleCheck" files="src[/\\]test[/\\]java"/>
+  <suppress checks="IndentationCheck" files=".*\.java$"/>
 </suppressions>

--- a/src/main/resources/fcrepo-checkstyle/checkstyle.xml
+++ b/src/main/resources/fcrepo-checkstyle/checkstyle.xml
@@ -29,6 +29,7 @@
   <!-- Checks that there are no tab characters ('\t') in the source code. -->
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
+    <property name="fileExtensions" value="java,css,js,xml"/>
   </module>
   <!-- License Header module disabled in favor of license-maven-plugin -->
   <module name="TreeWalker">
@@ -78,11 +79,21 @@
         value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"
       />
     </module>
-    <module name="Indentation"/>
+    <module name="Indentation">
+      <property name="throwsIndent" value="8"/>
+    </module>
+    <module name="SuppressWarningsHolder"/>
+    <module name="FinalLocalVariable"/>
+    <module name="FinalParameters"/>
+    <module name="GenericWhitespace"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="MultipleVariableDeclarations"/>
   </module>
   <!-- No Trailing Whitespace, except on lines that only have an asterisk (e.g. Javadoc comments) -->
   <module name="RegexpSingleline">
     <property name="format" value="(?&lt;!\*)\s+$|\*\s\s+$"/>
     <property name="message" value="Trailing whitespace"/>
+    <property name="fileExtensions" value="java,css,js,xml"/>
   </module>
+  <module name="SuppressWarningsFilter" />
 </module>


### PR DESCRIPTION
New checkstyle rules added and indentation check suppressed for Java files.  This shouldn't be merged until the work for https://www.pivotaltracker.com/story/show/71267176 is ready to be done.

Work done for https://www.pivotaltracker.com/story/show/70648784

Tickets generated from this:
- https://www.pivotaltracker.com/story/show/71262298 (Update Eclipse/IntelliJ config files -- can IntelliJ import Eclipse's so there is only one to maintain?)
- https://www.pivotaltracker.com/story/show/71266786 (Update documentation for fcrepo checkstyle and eclipse configs -- on Confluence and fcrepo Eclipse config files' README.md)
- https://www.pivotaltracker.com/story/show/71267176 (Run new rules across existing code base and clean up)
